### PR TITLE
Add <Nothing> in Solidity

### DIFF
--- a/Nothing.sol
+++ b/Nothing.sol
@@ -4,8 +4,7 @@ pragma solidity ^0.8.0;
 
 contract Nothing {
 
-    function getString() external pure returns (string memory) {
-        string memory _string = "Nothing";
-        return _string;
+    function getNothing() external pure returns (string memory) {
+        return "Nothing";
     }
 }

--- a/Nothing.sol
+++ b/Nothing.sol
@@ -4,5 +4,8 @@ pragma solidity ^0.8.0;
 
 contract Nothing {
 
-    string public _string = "Nothing";
+    function getString() external pure returns (string memory) {
+        string memory _string = "Nothing";
+        return _string;
+    }
 }

--- a/Nothing.sol
+++ b/Nothing.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+contract Nothing {
+
+    string public _string = "Nothing";
+}


### PR DESCRIPTION
- This is not the simplest, but the computationally least expensive way you can return a value, in this case "Nothing", from a smart contract written in Solidity, the most commonly used programming language to build smart contracts on EVM-compatible blockchains.